### PR TITLE
ORCAN4 validation

### DIFF
--- a/Orion-Effects-Lighting-ORCAN4.qxf
+++ b/Orion-Effects-Lighting-ORCAN4.qxf
@@ -36,14 +36,6 @@
   <Channel Number="3">White</Channel>
   <Channel Number="4">Amber</Channel>
   <Channel Number="5">UV</Channel>
-  <Head>
-   <Channel>0</Channel>
-   <Channel>1</Channel>
-   <Channel>2</Channel>
-   <Channel>3</Channel>
-   <Channel>4</Channel>
-   <Channel>5</Channel>
-  </Head>
  </Mode>
  <Mode Name="10ch">
   <Channel Number="0">Master dimmer</Channel>
@@ -56,24 +48,12 @@
   <Channel Number="7">White</Channel>
   <Channel Number="8">Amber</Channel>
   <Channel Number="9">UV</Channel>
-  <Head>
-   <Channel>0</Channel>
-   <Channel>1</Channel>
-   <Channel>2</Channel>
-   <Channel>3</Channel>
-   <Channel>4</Channel>
-   <Channel>5</Channel>
-   <Channel>6</Channel>
-   <Channel>7</Channel>
-   <Channel>8</Channel>
-   <Channel>9</Channel>
-  </Head>
  </Mode>
  <Physical>
-  <Bulb Type="" Lumens="0" ColourTemperature="0"/>
-  <Dimensions Weight="0" Width="0" Height="0" Depth="0"/>
-  <Lens Name="Other" DegreesMin="0" DegreesMax="0"/>
+  <Bulb Type="LED" Lumens="0" ColourTemperature="0"/>
+  <Dimensions Weight="2.5" Width="210" Height="260" Depth="100"/>
+  <Lens Name="Other" DegreesMin="40" DegreesMax="40"/>
   <Focus Type="Fixed" PanMax="0" TiltMax="0"/>
-  <Technical PowerConsumption="0" DmxConnector="3-pin"/>
+  <Technical PowerConsumption="120" DmxConnector="3-pin"/>
  </Physical>
 </FixtureDefinition>

--- a/Orion-Effects-Lighting-ORCAN4.qxf
+++ b/Orion-Effects-Lighting-ORCAN4.qxf
@@ -9,19 +9,19 @@
  <Manufacturer>Orion Effects Lighting</Manufacturer>
  <Model>ORCAN4</Model>
  <Type>Color Changer</Type>
- <Channel Name="Master dimmer" Preset="IntensityMasterDimmer"/>
- <Channel Name="Strobe" Preset="ShutterStrobeSlowFast"/>
+ <Channel Name="Master Dimming" Preset="IntensityMasterDimmer"/>
+ <Channel Name="Master Strobe" Preset="ShutterStrobeSlowFast"/>
  <Channel Name="Effect Select">
   <Group Byte="0">Effect</Group>
-  <Capability Min="0" Max="5">Single colour (manual)</Capability>
-  <Capability Min="6" Max="99">Colour step changing</Capability>
+  <Capability Min="0" Max="5">Single color (manual)</Capability>
+  <Capability Min="6" Max="99">Color step changing</Capability>
   <Capability Min="100" Max="150">Color fading</Capability>
-  <Capability Min="151" Max="200">Colour pulsing</Capability>
+  <Capability Min="151" Max="200">Color pulsing</Capability>
   <Capability Min="201" Max="255">Audio chase</Capability>
  </Channel>
- <Channel Name="Effect Speed">
+ <Channel Name="Speed Control">
   <Group Byte="0">Speed</Group>
-  <Capability Min="0" Max="255" Preset="SlowToFast">Effect speed slow to fast</Capability>
+  <Capability Min="0" Max="255" Preset="SlowToFast">Effects speed control, from slow to fast</Capability>
  </Channel>
  <Channel Name="Red" Preset="IntensityRed"/>
  <Channel Name="Green" Preset="IntensityGreen"/>
@@ -38,10 +38,10 @@
   <Channel Number="5">UV</Channel>
  </Mode>
  <Mode Name="10ch">
-  <Channel Number="0">Master dimmer</Channel>
-  <Channel Number="1">Strobe</Channel>
+  <Channel Number="0">Master Dimming</Channel>
+  <Channel Number="1">Master Strobe</Channel>
   <Channel Number="2">Effect Select</Channel>
-  <Channel Number="3">Effect Speed</Channel>
+  <Channel Number="3" ActsOn="2">Speed Control</Channel>
   <Channel Number="4">Red</Channel>
   <Channel Number="5">Green</Channel>
   <Channel Number="6">Blue</Channel>


### PR DESCRIPTION
- Fixes #6 (see comments in db1be9f8b498fe1ad498d224145c9118e9ba8a8e for detail on exactly what was required to fix each error)
- Change some of the channel and capability names to match what Orion has used in the manual (where possible - when using preset channels, we cannot easily change the capability names.)

Passes the QLC+ fixture validator.

Don't merge until after Skeeter 2026, just in case this introduces issues.